### PR TITLE
op3: Hide sRGB toggle in developer options

### DIFF
--- a/overlay/frameworks/base/packages/SettingsLib/res/values/arrays.xml
+++ b/overlay/frameworks/base/packages/SettingsLib/res/values/arrays.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+**
+** Copyright 2015 The Android Open Source Project
+**           2017 The LineageOS Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+<resources>
+    <!-- IDs for each color mode. The values must match the corresponding constants in
+         android.view.Display -->
+    <integer-array name="color_mode_ids">
+        <item>0</item>
+        <item>-1</item>
+        <item>-1</item>
+    </integer-array>
+</resources>


### PR DESCRIPTION
 * This is only available on Nexus/Pixel devices, and we have our own
   implementation in livedisplay.

Change-Id: I8343e4986d7dd8413bd8d36dfad0309a4c08026e